### PR TITLE
cache downloaded archive without cp

### DIFF
--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -1,0 +1,32 @@
+name: Test Cache
+on: [push]
+jobs:
+  Use-Action:
+    name: Use Action
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: download-ipfs-distribution-action
+      - uses: ./download-ipfs-distribution-action
+  Use-Action-Again:
+    needs: [Use-Action]
+    name: Use Action Again
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: download-ipfs-distribution-action
+      - id: distribution
+        uses: ./download-ipfs-distribution-action
+      - if: ${{ steps.distribution.outputs.cache-hit != 'true' }}
+        run: exit 1
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        name: [fs-repo-migrations, gx, gx-go, ipfs-cluster-ctl, ipfs-cluster-follow, ipfs-cluster-service, ipfs-ds-convert, ipfs-update, ipget, libp2p-relay-daemon]
+        name: [go-ipfs, fs-repo-migrations, gx, gx-go, ipfs-cluster-ctl, ipfs-cluster-follow, ipfs-cluster-service, ipfs-ds-convert, ipfs-update, ipget, libp2p-relay-daemon]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -17,6 +17,7 @@ jobs:
         uses: ./download-ipfs-distribution-action
         with:
           name: ${{ matrix.name }}
+          cache: false
       # ipget for linux-amd64 requires GLIBC_2.32 but GLIBC_2.31 is installed
       - if: ${{ matrix.os != 'ubuntu-latest' || matrix.name != 'ipget' }}
         run: ${{ steps.distribution.outputs.executable }} --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- archive caching controlled by boolean input `cache`
+
+### Changed
+- `working-directory` default from current dir to temp dir
 
 ## [1.0.2] - 2021-12-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The action downloads a distribution from [dist.ipfs.io](https://dist.ipfs.io) an
 | --- | --- | --- |
 | name | Name of the distribution to download | go-ipfs |
 | version | Version of the distribution to download | *last stable version* |
-| working-directory | Directory where the action is going to be performed; the downloaded artifacts are cleaned up afterwards | *current directory* |
+| working-directory | Directory where the action is going to be performed; the downloaded artifacts are cleaned up afterwards | runner.temp |
 | install-directory | Directory where the executable is going to be copied | **linux, macos:** /usr/local/bin; **windows:** /usr/bin |
+| cache | A boolean value to indicate the archive cache should be used | true |
 
 ## Outputs
 
@@ -17,6 +18,7 @@ The action downloads a distribution from [dist.ipfs.io](https://dist.ipfs.io) an
 | --- | --- | --- |
 | executable | The name of the executable | ipfs |
 | executables | The names of all the executables | ["ipfs"] |
+| cache-hit | A boolean value to indicate the archive was downloaded from cache | true |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,15 @@ inputs:
     description: 'Version of the distribution to download(defaults to latest stable version)'
     required: false
   working-directory:
-    description: "Directory where the action is going to be performed(defaults to current directory)"
+    description: "Directory where the action is going to be performed(defaults to temp directory)"
     required: false
   install-directory:
     description: "Directory where the executable is going to be copied(defaults to /usr/local/bin or /usr/bin on windows)"
     required: false
+  cache:
+    description: "A boolean value to indicate the archive cache should be used"
+    required: true
+    default: 'true'
 outputs:
   executable:
     description: "The name of the executable"
@@ -21,16 +25,20 @@ outputs:
   executables:
     description: "The names of all the executables"
     value: ${{ steps.copy.outputs.executables }}
+  cache-hit:
+    description: "A boolean value to indicate the archive was downloaded from cache"
+    value: ${{ steps.archive-cache.outputs.cache-hit }}
 runs:
   using: "composite"
   steps:
-    - run: mkdir "${{ inputs.name }}"
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
     - id: system
       run: |
+        WORKING_DIRECTORY="${{ inputs.working-directory }}"
         OS="$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')"
         ARCH="$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')"
+        if [ -z "$WORKING_DIRECTORY" ]; then
+          WORKING_DIRECTORY="${{ runner.temp }}"
+        fi
         case "$OS" in
           macos) OS="darwin" ;;
         esac
@@ -38,12 +46,16 @@ runs:
           x86) ARCH="386" ;;
           x64) ARCH="amd64" ;;
         esac
+        echo "working-directory=$WORKING_DIRECTORY"
         echo "os=$OS"
         echo "arch=$ARCH"
+        echo "::set-output name=working-directory::$WORKING_DIRECTORY"
         echo "::set-output name=os::$OS"
         echo "::set-output name=arch::$ARCH"
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+    - run: mkdir "${{ inputs.name }}"
+      shell: bash
+      working-directory: ${{ steps.system.outputs.working-directory }}
     - id: inputs
       run: |
         VERSION="${{ inputs.version }}"
@@ -64,7 +76,7 @@ runs:
         echo "::set-output name=version::$VERSION"
         echo "::set-output name=install-directory::$INSTALL_DIRECTORY"
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
     - id: dist
       run: |
         curl --retry 5 --no-progress-meter --output "${{ inputs.name }}/dist.json" "https://dist.ipfs.io/${{ inputs.name }}/${{ steps.inputs.outputs.version }}/dist.json"
@@ -78,21 +90,18 @@ runs:
         echo "::set-output name=archive::$ARCHIVE"
         echo "::set-output name=sha512::$SHA512"
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
     - id: archive-cache
+      if: inputs.cache == 'true'
       uses: actions/cache@v2
       with:
-        path: ~/.cache/${{ steps.dist.outputs.archive }}
-        key: dist-${{ steps.dist.outputs.archive }}
-    - if: steps.archive-cache.outputs.cache-hit == 'true'
-      run: cp ~/.cache/${{ steps.dist.outputs.archive }} .
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-    - if: steps.archive-cache.outputs.cache-hit != 'true'
+        path: ${{ steps.system.outputs.working-directory }}/${{ steps.dist.outputs.archive }}
+        key: dist-v0-${{ steps.dist.outputs.archive }}
+    - if: inputs.cache != 'true' || steps.archive-cache.outputs.cache-hit != 'true'
       run: curl --retry 5 --no-progress-meter --output "${{ steps.dist.outputs.archive }}" "https://dist.ipfs.io/${{ inputs.name }}/${{ steps.inputs.outputs.version }}${{ steps.dist.outputs.link }}"
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
-    - if: ${{ steps.dist.outputs.sha512 != '' }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
+    - if: steps.dist.outputs.sha512 != ''
       run: |
         CMD="sha512sum"
         if [ "${{ runner.os }}" == "macOS" ]; then
@@ -100,14 +109,14 @@ runs:
         fi
         echo "${{ steps.dist.outputs.sha512 }}  ${{ steps.dist.outputs.archive }}" | $CMD --check
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
     - run: |
         case "${{ steps.dist.outputs.archive }}" in
           *.tar.gz) tar -zxf "${{ steps.dist.outputs.archive }}" ;;
           *.zip) unzip "${{ steps.dist.outputs.archive }}" ;;
         esac
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
     - id: copy
       run: |
         EXECUTABLES=()
@@ -122,11 +131,9 @@ runs:
         echo "::set-output name=executable::$EXECUTABLE"
         echo "::set-output name=executables::$EXECUTABLES"
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
-    - if: ${{ always() }}
+      working-directory: ${{ steps.system.outputs.working-directory }}
+    - if: always()
       run: |
         rm -r "${{ inputs.name }}"
-        mkdir -p ~/.cache/
-        mv "${{ steps.dist.outputs.archive }}" ~/.cache/
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ steps.system.outputs.working-directory }}


### PR DESCRIPTION
This PR builds up on https://github.com/ipfs/download-ipfs-distribution-action/pull/9.

###### Changes
- add a test for the caching feature
- add `go-ipfs` to the list of tested distributions
- update CHANGELOG and README
- change default for `working-directory` from current dir to `runner.temp`
- unpack cache in the desired location to skip `cp`

@lidel WDYT?