### PR TITLE
replace unzip with 7zip

### DIFF
--- a/.github/workflows/test-msys2.yml
+++ b/.github/workflows/test-msys2.yml
@@ -1,0 +1,19 @@
+name: Test msys2
+on: [push]
+jobs:
+  Use-Action:
+    name: Use Action
+    runs-on: windows-latest
+    steps:
+      - run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+        shell: bash
+      - uses: actions/checkout@v2
+        with:
+          path: download-ipfs-distribution-action
+      - id: distribution
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: go-ipfs
+          cache: false
+      - run: ${{ steps.distribution.outputs.executable }} --help
+        shell: bash

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
     - run: |
         case "${{ steps.dist.outputs.archive }}" in
           *.tar.gz) tar -zxf "${{ steps.dist.outputs.archive }}" ;;
-          *.zip) unzip "${{ steps.dist.outputs.archive }}" ;;
+          *.zip) 7z e "${{ steps.dist.outputs.archive }}" -o${{ inputs.name }} ;;
         esac
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}


### PR DESCRIPTION
I noticed here that `unzip` sometimes runs into troubles on `msys2` - https://github.com/ipfs-shipyard/git-remote-ipld/actions/runs/1944692238

The issues look similar to https://github.com/msys2/MSYS2-packages/issues/1966 but I couldn't apply the "fixes" proposed there.

`7z` seems to be working as expected: https://github.com/galargh/git-remote-ipld/actions/runs/1946058088