### PR TITLE
chore: switch to dist.ipfs.tech

### DIFF
--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           path: download-ipfs-distribution-action
       - if: runner.os != 'Windows'
-        run: echo '127.0.0.1 dist.ipfs.io' | sudo tee -a /etc/hosts
+        run: echo '127.0.0.1 dist.ipfs.tech' | sudo tee -a /etc/hosts
         shell: bash
       - if: runner.os == 'Windows'
-        run: echo '127.0.0.1 dist.ipfs.io' | tee -a C:/windows/system32/drivers/etc/hosts
+        run: echo '127.0.0.1 dist.ipfs.tech' | tee -a C:/windows/system32/drivers/etc/hosts
         shell: bash
       - id: distribution
         uses: ./download-ipfs-distribution-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,4 +37,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-12-14
 ### Added
-- action that downloads a distribution from [dist.ipfs.io](https://dist.ipfs.io) and puts it on `PATH`
+- action that downloads a distribution from [dist.ipfs.tech](https://dist.ipfs.tech) and puts it on `PATH`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Download IPFS Distribution Action
 
-The action downloads a distribution from [dist.ipfs.io](https://dist.ipfs.io) and puts it on `PATH`.
+The action downloads a distribution from [dist.ipfs.tech](https://dist.ipfs.tech) and puts it on `PATH`.
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Download IPFS Distribution'
-description: 'Download executable from dist.ipfs.io'
+description: 'Download executable from dist.ipfs.tech'
 inputs:
   name:
     description: 'Name of the distribution to download'
@@ -64,7 +64,7 @@ runs:
         INSTALL_DIRECTORY="${{ inputs.install-directory }}"
         ARTIFACTS='[]'
         if [ -z "$VERSION" ]; then
-          curl --retry 5 --no-progress-meter --output "${{ inputs.name }}/versions" "https://dist.ipfs.io/${{ inputs.name }}/versions" || (
+          curl --retry 5 --no-progress-meter --output "${{ inputs.name }}/versions" "https://dist.ipfs.tech/${{ inputs.name }}/versions" || (
             [[ '${{ inputs.cache }}' == 'true' ]] &&
             echo "Using fallback cache" &&
             gh run download --repo '${{ github.repository }}' --name 'download-ipfs-distribution-action_${{ inputs.name }}_versions' --dir '${{ inputs.name }}' &&
@@ -92,7 +92,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        curl --retry 5 --no-progress-meter --output "${{ inputs.name }}/dist.json" "https://dist.ipfs.io/${{ inputs.name }}/${{ steps.inputs.outputs.version }}/dist.json" || (
+        curl --retry 5 --no-progress-meter --output "${{ inputs.name }}/dist.json" "https://dist.ipfs.tech/${{ inputs.name }}/${{ steps.inputs.outputs.version }}/dist.json" || (
           [[ '${{ inputs.cache }}' == 'true' ]] &&
           echo "Using fallback cache" &&
           gh run download --repo '${{ github.repository }}' --name 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}_dist.json' --dir '${{ inputs.name }}' &&
@@ -113,7 +113,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        curl --retry 5 --no-progress-meter --output "${{ steps.dist.outputs.archive }}" "https://dist.ipfs.io/${{ inputs.name }}/${{ steps.inputs.outputs.version }}${{ steps.dist.outputs.link }}" || (
+        curl --retry 5 --no-progress-meter --output "${{ steps.dist.outputs.archive }}" "https://dist.ipfs.tech/${{ inputs.name }}/${{ steps.inputs.outputs.version }}${{ steps.dist.outputs.link }}" || (
           [[ '${{ inputs.cache }}' == 'true' ]] &&
           echo "Using fallback cache" &&
           gh run download --repo '${{ github.repository }}' --name 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}${{ steps.dist.outputs._link }}' &&


### PR DESCRIPTION
> Part of  https://github.com/protocol/bifrost-infra/issues/2018

This PR switches to the .tech version, isolating package downloads from the public gateway, which may be blocked at the DNS level.

