### PR TITLE
chore: upgrade upload-artifact to v3

### DIFF
--- a/.github/workflows/test-cache-download.yml
+++ b/.github/workflows/test-cache-download.yml
@@ -1,27 +1,21 @@
-name: Test Cache
+name: Test Cache Download
 on: [push]
 jobs:
-  Use-Action:
-    name: Use Action
+  Cache-Download:
+    name: Cache Download
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - name: Wait for Cache Download
+        uses: lewagon/wait-on-check-action@752bfae19aef55dab12a00bc36d48acc46b77e9d # v1.1.1
         with:
-          path: download-ipfs-distribution-action
-      - uses: ./download-ipfs-distribution-action
-  Use-Action-Again:
-    needs: [Use-Action]
-    name: Use Action Again
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-      fail-fast: false
-    steps:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          check-name: 'Cache Upload (${{ matrix.os }})'
       - uses: actions/checkout@v2
         with:
           path: download-ipfs-distribution-action

--- a/.github/workflows/test-cache-download.yml
+++ b/.github/workflows/test-cache-download.yml
@@ -1,6 +1,18 @@
 name: Test Cache Download
 on: [push]
 jobs:
+  Wait-For-Cache-Upload:
+    name: Wait for Cache Upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Cache Upload
+        uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd # v1.1.2
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+          check-regexp: 'Cache Upload \(.*\)'
+          allowed-conclusions: success
   Cache-Download:
     name: Cache Download
     runs-on: ${{ matrix.os }}
@@ -9,14 +21,6 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - name: Wait for Cache Upload
-        uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd # v1.1.2
-        with:
-          ref: ${{ github.ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
-          check-name: 'Cache Upload (${{ matrix.os }})'
-          allowed-conclusions: success
       - uses: actions/checkout@v2
         with:
           path: download-ipfs-distribution-action

--- a/.github/workflows/test-cache-download.yml
+++ b/.github/workflows/test-cache-download.yml
@@ -9,13 +9,14 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - name: Wait for Cache Download
-        uses: lewagon/wait-on-check-action@752bfae19aef55dab12a00bc36d48acc46b77e9d # v1.1.1
+      - name: Wait for Cache Upload
+        uses: lewagon/wait-on-check-action@e2558238c09778af25867eb5de5a3ce4bbae3dcd # v1.1.2
         with:
           ref: ${{ github.ref }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          wait-interval: 20
           check-name: 'Cache Upload (${{ matrix.os }})'
+          allowed-conclusions: success
       - uses: actions/checkout@v2
         with:
           path: download-ipfs-distribution-action

--- a/.github/workflows/test-cache-upload.yml
+++ b/.github/workflows/test-cache-upload.yml
@@ -1,0 +1,15 @@
+name: Test Cache Upload
+on: [push]
+jobs:
+  Cache-Upload:
+    name: Cache Upload
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: download-ipfs-distribution-action
+      - uses: ./download-ipfs-distribution-action

--- a/action.yml
+++ b/action.yml
@@ -152,18 +152,18 @@ runs:
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
     - if: inputs.cache == 'true' && inputs.version == '' && steps.inputs.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_versions'
         path: '${{ steps.system.outputs.working-directory }}/${{ inputs.name }}/versions'
         retention-days: 1
     - if: inputs.cache == 'true' && ! contains(fromJson(steps.inputs.outputs.artifacts), format('download-ipfs-distribution-action_{0}_{1}_dist.json', inputs.name, steps.inputs.outputs.version ))
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}_dist.json'
         path: '${{ steps.system.outputs.working-directory }}/${{ inputs.name }}/dist.json'
     - if: inputs.cache == 'true' && ! contains(fromJson(steps.inputs.outputs.artifacts), format('download-ipfs-distribution-action_{0}_{1}{2}', inputs.name, steps.inputs.outputs.version, steps.dist.outputs._link))
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}${{ steps.dist.outputs._link }}'
         path: '${{ steps.system.outputs.working-directory }}/${{ steps.dist.outputs.archive }}'


### PR DESCRIPTION
... and split test-cache workflow in 2 because, as it turns out, the way in which we download artifacts doesn't work until the workflow that uploads artifacts finished.