### PR TITLE
fix: use actions/upload-artifact v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,18 +162,18 @@ runs:
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
     - if: inputs.cache == 'true' && inputs.version == '' && steps.inputs.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_versions'
         path: '${{ steps.system.outputs.working-directory }}/${{ inputs.name }}/versions'
         retention-days: 1
     - if: inputs.cache == 'true' && ! contains(fromJson(steps.inputs.outputs.artifacts), format('download-ipfs-distribution-action_{0}_{1}_dist.json', inputs.name, steps.inputs.outputs.version ))
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}_dist.json'
         path: '${{ steps.system.outputs.working-directory }}/${{ inputs.name }}/dist.json'
     - if: inputs.cache == 'true' && ! contains(fromJson(steps.inputs.outputs.artifacts), format('download-ipfs-distribution-action_{0}_{1}{2}', inputs.name, steps.inputs.outputs.version, steps.dist.outputs._link))
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: 'download-ipfs-distribution-action_${{ inputs.name }}_${{ steps.inputs.outputs.version }}${{ steps.dist.outputs._link }}'
         path: '${{ steps.system.outputs.working-directory }}/${{ steps.dist.outputs.archive }}'


### PR DESCRIPTION
v3 got removed:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

and currently breaks CI:
https://github.com/ipfs/distributions/actions/runs/12936619703/job/36082624581?pr=1123#step:4:6