### PR TITLE
feat: fetch distributions from github releases

### DIFF
--- a/.github/workflows/test-cache-download.yml
+++ b/.github/workflows/test-cache-download.yml
@@ -25,19 +25,26 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: download-ipfs-distribution-action
-      # Block github.com, where the release asset download starts, so the artifact cannot be
-      # fetched. resolve still reaches api.github.com for the version and digest, and the
-      # Actions cache service is a separate host, so a passing run with cache-hit proves the
-      # archive was restored from cache and the download was skipped, not re-fetched. The
-      # hosts file is backed up and restored below, so this is safe on self-hosted runners too
-      # (GitHub-hosted runners are ephemeral and discard the change regardless).
-      - name: Block github.com
+      # Permit release metadata requests but reject the octet-stream asset request. A passing
+      # run therefore proves that the archive was restored and the download step was skipped.
+      - name: Reject release asset downloads
         run: |
-          set -euo pipefail
-          priv() { if [ "$RUNNER_OS" = Windows ]; then "$@"; else sudo "$@"; fi; }
-          if [ "$RUNNER_OS" = Windows ]; then hosts="C:/Windows/System32/drivers/etc/hosts"; else hosts=/etc/hosts; fi
-          priv cp "$hosts" "$hosts.dl-bak"
-          echo '127.0.0.1 github.com' | priv tee -a "$hosts" >/dev/null
+          shim="$RUNNER_TEMP/reject-asset-download"
+          mkdir -p "$shim"
+          real_curl="$(command -v curl)"
+          echo "REAL_CURL=$real_curl" >> "$GITHUB_ENV"
+          echo "$shim" >> "$GITHUB_PATH"
+          cat > "$shim/curl" <<'EOF'
+          #!/usr/bin/env bash
+          for argument in "$@"; do
+            if [ "$argument" = "Accept: application/octet-stream" ]; then
+              echo "release asset download was not expected" >&2
+              exit 99
+            fi
+          done
+          exec "$REAL_CURL" "$@"
+          EOF
+          chmod +x "$shim/curl"
         shell: bash
       - id: distribution
         uses: ./download-ipfs-distribution-action
@@ -50,12 +57,4 @@ jobs:
         run: exit 1
         shell: bash
       - run: ${{ steps.distribution.outputs.executable }} --help
-        shell: bash
-      - name: Restore hosts
-        if: always()
-        run: |
-          set -euo pipefail
-          priv() { if [ "$RUNNER_OS" = Windows ]; then "$@"; else sudo "$@"; fi; }
-          if [ "$RUNNER_OS" = Windows ]; then hosts="C:/Windows/System32/drivers/etc/hosts"; else hosts=/etc/hosts; fi
-          if [ -f "$hosts.dl-bak" ]; then priv mv "$hosts.dl-bak" "$hosts"; fi
         shell: bash

--- a/.github/workflows/test-msys2.yml
+++ b/.github/workflows/test-msys2.yml
@@ -5,7 +5,7 @@ jobs:
     name: Use Action
     runs-on: windows-latest
     steps:
-      - run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+      - run: echo "C:/msys64/usr/bin" >> "$GITHUB_PATH"
         shell: bash
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,13 @@
+name: Test scripts
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: bash tests/test-scripts.sh
+      - run: shellcheck scripts/*.sh tests/*.sh
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -no-color -shellcheck= .github/workflows/*.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,62 @@ jobs:
           cache: false
       - run: ${{ steps.distribution.outputs.executable }} --help
         shell: bash
+  Repository-Override:
+    name: Repository Override
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: download-ipfs-distribution-action
+      - id: distribution
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: kubo
+          version: v0.42.0
+          github-repo: ipfs/kubo
+          cache: false
+      - run: ${{ steps.distribution.outputs.executable }} --help
+        shell: bash
+  Expected-Failures:
+    name: Expected Failures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: download-ipfs-distribution-action
+      - id: missing-digest
+        continue-on-error: true
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: kubo
+          version: v0.35.0
+          cache: false
+      - if: steps.missing-digest.outcome != 'failure'
+        run: exit 1
+      - id: api-error
+        continue-on-error: true
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: kubo
+          version: v0.42.0
+          github-token: invalid-token
+          cache: false
+      - if: steps.api-error.outcome != 'failure'
+        run: exit 1
+      - id: unsafe-name
+        continue-on-error: true
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: ../unsafe
+          github-repo: ipfs/kubo
+          cache: false
+      - if: steps.unsafe-name.outcome != 'failure'
+        run: exit 1
+      - id: missing-repository
+        continue-on-error: true
+        uses: ./download-ipfs-distribution-action
+        with:
+          name: unknown-distribution
+          cache: false
+      - if: steps.missing-repository.outcome != 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0] - 2026-07-18
 ### Added
 - `github-repo` input to override the built-in distribution-to-repo map (`distributions.json`) for distributions not in the map or to use a mirror
+- `github-token` input for reading releases and assets from another private repository
 
 ### Changed
 - release binaries are fetched from GitHub releases
-- when `version` is empty, resolve to the latest non-prerelease release that actually ships a binary for the runner; a newer release with no (or non-conforming) assets is skipped
+- when `version` is empty, use GitHub's designated latest stable, non-draft release when it ships a verifiable binary; otherwise fall back to the newest published stable release that does
 - checksums come from the release API `digest` (sha256); the archive is verified on every run, including cache hits, and a missing or mismatched checksum fails the action. Releases predating GitHub's release-asset digests (2025-06-03) carry no digest and are unsupported (for kubo, `v0.35.0` and older)
-- caching is now cache-first: the archive is restored before any download, keyed on the resolved concrete version (`<prefix>-<name>-<version>-<os>-<arch>`); a cache hit skips the download but the archive is still verified
+- caching is now cache-first: the archive is restored before any download, keyed on the repository, resolved concrete version, and digest (`<prefix>-<repo>-<name>-<version>-<os>-<arch>-<sha256>`); a cache hit skips the download but the archive is still verified
 - `cache-hit` output now reports whether the archive was restored from cache instead of downloaded
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The action downloads an IPFS distribution from [GitHub releases](https://github.
 ## How it works
 
 1. The distribution `name` is mapped to a GitHub `owner/repo` (see [`distributions.json`](distributions.json)); the `github-repo` input overrides the map.
-2. When `version` is empty, the latest non-prerelease release that actually ships a binary for the runner is used. A newer release with no (or non-conforming) assets is skipped, so the action never resolves to a version GitHub cannot serve.
+2. When `version` is empty, GitHub's designated latest stable, non-draft release is used if it ships a verifiable binary for the runner. If that release is incomplete, the newest published stable release with a matching binary and digest is used instead.
 3. The asset name is built from the version, OS and arch (`<name>_<version>_<os>-<arch>.tar.gz`, or `.zip` on windows); there is no manifest to fetch.
 4. The archive is restored from cache first; a hit skips the download. It is checksum-verified on every run, so a corrupt download or a tampered cache entry is caught.
 
@@ -16,8 +16,9 @@ Each download is verified against the release API's `sha256` digest; a missing o
 | Name | Description | Default |
 | --- | --- | --- |
 | name | Name of the distribution to download | kubo |
-| version | Version of the distribution to download | *latest release that ships binaries* |
+| version | Version of the distribution to download | *latest stable, non-draft release that ships a verifiable binary* |
 | github-repo | GitHub `owner/repo` hosting the release binaries; overrides the built-in map (set it for distributions not in the map or to use a mirror) | *from [`distributions.json`](distributions.json)* |
+| github-token | Token used to read release metadata and assets. The default token works for public repositories and the workflow repository; pass a PAT or GitHub App token with `Contents: read` for another private repository | `github.token` |
 | working-directory | Directory where the action is going to be performed; the downloaded artifacts are cleaned up afterwards | runner.temp |
 | install-directory | Directory where the executable is going to be copied | **linux, macos:** /usr/local/bin; **windows:** /usr/bin |
 | cache | Whether the resolved archive is cached and restored before downloading | true |
@@ -33,12 +34,12 @@ Each download is verified against the release API's `sha256` digest; a missing o
 
 ## Caching
 
-Caching is cache-first: before any download the archive is restored from the GitHub Actions cache, and a cache hit skips the download. The archive is still verified on every run, so a tampered cache entry is caught rather than trusted. The version is still resolved on every run (a cheap release lookup), so the cache key always pins a concrete version, never `latest`, and a moving `latest` never serves a stale binary. The key is `<prefix>-<name>-<version>-<os>-<arch>`. Set `cache: false` to always download.
+Caching is cache-first: before any download the archive is restored from the GitHub Actions cache, and a cache hit skips the download. The archive is still verified on every run, so a tampered cache entry is caught rather than trusted. The version and digest are resolved on every run, so a moving `latest` never serves a stale binary and a re-uploaded release asset gets a new cache entry. The key is `<prefix>-<repo>-<name>-<version>-<os>-<arch>-<sha256>`. Set `cache: false` to always download.
 
 ## Example
 
 ```yaml
-- uses: ipfs/download-ipfs-distribution-action@v1
+- uses: ipfs/download-ipfs-distribution-action@v2
   with:
     name: kubo
 - run: ipfs --help
@@ -48,10 +49,40 @@ Caching is cache-first: before any download the archive is restored from the Git
 Download a distribution from an alternative repo (e.g. a fork, for testing):
 
 ```yaml
-- uses: ipfs/download-ipfs-distribution-action@v1
+- uses: ipfs/download-ipfs-distribution-action@v2
   with:
     name: kubo
     github-repo: my-org/kubo
 - run: ipfs --help
   shell: bash
 ```
+
+### Private release repository
+
+The job's default `GITHUB_TOKEN` is limited to the repository containing the workflow. To download from another private repository, pass a fine-grained PAT or GitHub App token that has `Contents: read` access to the release repository:
+
+```yaml
+- uses: ipfs/download-ipfs-distribution-action@v2
+  with:
+    name: kubo
+    github-repo: my-org/private-kubo
+    github-token: ${{ secrets.RELEASES_TOKEN }}
+```
+
+The token is sent only to GitHub's release metadata and release asset API endpoints. It is not written to action outputs, cache keys, or logs.
+
+## Upgrading from v1
+
+Version 2 is opt-in. The `v1` tag remains on `v1.4.2`; change the action reference to `@v2` only after checking the distribution name and pinned version.
+
+| Distribution | First supported stable version in v2 |
+| --- | --- |
+| `kubo` | `v0.36.0` |
+| `ipget` | `v0.13.1` |
+| `ipfs-cluster-ctl`, `ipfs-cluster-follow`, `ipfs-cluster-service` | `v1.1.6` |
+
+- Change the legacy `go-ipfs` name to `kubo`.
+- Assets without a GitHub-provided SHA-256 digest are unsupported. Upgrade an older pin or remain on `@v1` temporarily.
+- Distributions not listed in [`distributions.json`](distributions.json) need a conforming GitHub release repository supplied through `github-repo`; otherwise use a different installer.
+- `cache-hit` now reports an ordinary cache restore. Existing v1 caches are ignored by the new repository-and-digest-aware keys and do not need to be deleted.
+- Release metadata is required even on a cache hit. If the GitHub API is unavailable, the action fails closed rather than installing an archive it cannot verify against current metadata.

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,13 @@ inputs:
     required: true
     default: 'kubo'
   version:
-    description: 'Version of the distribution to download (defaults to the latest release that ships binaries)'
+    description: 'Version of the distribution to download (defaults to the latest stable, non-draft release that ships a verifiable binary)'
     required: false
   github-repo:
     description: "GitHub owner/repo that hosts the release binaries (overrides the built-in distributions.json map; set it for distributions not in the map or to use a mirror)"
+    required: false
+  github-token:
+    description: "GitHub token used to read release metadata and assets (defaults to github.token; pass a token with Contents: read for a private repository)"
     required: false
   working-directory:
     description: "Directory where the action is going to be performed (defaults to temp directory)"
@@ -42,12 +45,15 @@ runs:
       env:
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        set -euo pipefail
         OS="$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
         ARCH="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
         if [ -z "$WORKING_DIRECTORY" ]; then
           WORKING_DIRECTORY="$RUNNER_TEMP"
         fi
+        case "$WORKING_DIRECTORY" in
+          *$'\n'*|*$'\r'*) echo "::error::working-directory must not contain newlines"; exit 1 ;;
+        esac
+        mkdir -p "$WORKING_DIRECTORY"
         case "$OS" in
           macos) OS="darwin" ;;
         esac
@@ -64,122 +70,31 @@ runs:
           echo "arch=$ARCH"
         } >> "$GITHUB_OUTPUT"
       shell: bash
-    - env:
+    - id: prepare
+      env:
         NAME: ${{ inputs.name }}
-      run: mkdir -p "$NAME"
+      run: |
+        if ! [[ "$NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+          echo "::error::name must start with an alphanumeric character and contain only letters, numbers, dots, underscores, or hyphens"
+          exit 1
+        fi
+        mkdir -p "$NAME"
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
     # Resolve the GitHub repo, the concrete version, the release asset URL, its checksum,
     # and the immutable cache key.
     - id: resolve
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         NAME: ${{ inputs.name }}
-        INPUT_VERSION: ${{ inputs.version }}
-        INPUT_REPO: ${{ inputs.github-repo }}
-        INPUT_INSTALL_DIRECTORY: ${{ inputs.install-directory }}
+        VERSION: ${{ inputs.version }}
+        GITHUB_REPO: ${{ inputs.github-repo }}
+        INSTALL_DIRECTORY: ${{ inputs.install-directory }}
         OS: ${{ steps.system.outputs.os }}
         ARCH: ${{ steps.system.outputs.arch }}
         PREFIX: ${{ inputs.prefix }}
-        ACTION_PATH: ${{ github.action_path }}
       run: |
-        set -euo pipefail
-
-        if [ "$OS" = "windows" ]; then EXT="zip"; else EXT="tar.gz"; fi
-        SUFFIX="${OS}-${ARCH}.${EXT}"
-
-        # Resolve owner/repo: explicit override wins, otherwise the built-in map.
-        REPO="$INPUT_REPO"
-        if [ -z "$REPO" ] && [ -f "$ACTION_PATH/distributions.json" ]; then
-          REPO="$(jq -r --arg n "$NAME" '.[$n] // empty' "$ACTION_PATH/distributions.json")"
-        fi
-        if [ -z "$REPO" ]; then
-          echo "::error::No GitHub repository for '$NAME'. Add it to distributions.json or set the github-repo input."
-          exit 1
-        fi
-
-        gh_api() {
-          local url="https://api.github.com/$1"
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            curl -fsSL --retry 5 --connect-timeout 30 --max-time 120 \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" "$url"
-          else
-            curl -fsSL --retry 5 --connect-timeout 30 --max-time 120 \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" "$url"
-          fi
-        }
-
-        VERSION="$INPUT_VERSION"
-        GITHUB_URL=""
-        CHECKSUM=""
-
-        if [ -n "$VERSION" ]; then
-          # Pinned version: the asset URL is deterministic, so the download works even if
-          # the API is unreachable. Fetch the asset's digest for verification when possible.
-          ARCHIVE="${NAME}_${VERSION}_${SUFFIX}"
-          GITHUB_URL="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
-          if REL="$(gh_api "repos/$REPO/releases/tags/$VERSION")"; then
-            CHECKSUM="$(printf '%s' "$REL" | jq -r --arg want "$ARCHIVE" \
-              '((.assets[] | select(.name == $want) | .digest) // "")' | head -n1 || true)"
-            CHECKSUM="${CHECKSUM#sha256:}"
-          fi
-        else
-          # Implicit latest: highest-version non-prerelease release that ships our asset.
-          # GitHub lists releases newest-first by date, so a later backport of an older
-          # line would sort ahead; pick by version instead. A release with no (or
-          # non-conforming) binaries is skipped.
-          if ! RELS="$(gh_api "repos/$REPO/releases?per_page=100")"; then
-            echo "::error::Could not query GitHub releases for $REPO"
-            exit 1
-          fi
-          LINE="$(printf '%s' "$RELS" | jq -r --arg name "$NAME" --arg suffix "$SUFFIX" '
-            [ .[]
-              | select(.draft == false and .prerelease == false and (.tag_name | test("^v?[0-9]+(\\.[0-9]+)*$")))
-              | . as $r | ($name + "_" + $r.tag_name + "_" + $suffix) as $want
-              | ($r.assets[] | select(.name == $want)) as $a
-              | {tag: $r.tag_name, url: $a.browser_download_url, digest: ($a.digest // "")} ]
-            | (max_by(.tag | ltrimstr("v") | split(".") | map(tonumber)) // empty)
-            | [.tag, .url, .digest] | @tsv' | head -n1 || true)"
-          if [ -z "$LINE" ]; then
-            echo "::error::No release of $REPO ships '${NAME}_<version>_${SUFFIX}'"
-            exit 1
-          fi
-          VERSION="$(printf '%s' "$LINE" | cut -f1)"
-          GITHUB_URL="$(printf '%s' "$LINE" | cut -f2)"
-          CHECKSUM="$(printf '%s' "$LINE" | cut -f3)"
-          CHECKSUM="${CHECKSUM#sha256:}"
-          ARCHIVE="${NAME}_${VERSION}_${SUFFIX}"
-        fi
-
-        INSTALL_DIRECTORY="$INPUT_INSTALL_DIRECTORY"
-        if [ -z "$INSTALL_DIRECTORY" ]; then
-          if [ "$OS" = "windows" ]; then
-            INSTALL_DIRECTORY="/usr/bin"
-          else
-            INSTALL_DIRECTORY="/usr/local/bin"
-          fi
-        fi
-
-        CACHE_KEY="${PREFIX}-${NAME}-${VERSION}-${OS}-${ARCH}"
-
-        echo "repo=$REPO"
-        echo "version=$VERSION"
-        echo "archive=$ARCHIVE"
-        echo "github-url=$GITHUB_URL"
-        echo "checksum=${CHECKSUM:+sha256:}${CHECKSUM:-<none>}"
-        echo "cache-key=$CACHE_KEY"
-        echo "install-directory=$INSTALL_DIRECTORY"
-
-        {
-          echo "archive=$ARCHIVE"
-          echo "github-url=$GITHUB_URL"
-          echo "checksum=$CHECKSUM"
-          echo "cache-key=$CACHE_KEY"
-          echo "install-directory=$INSTALL_DIRECTORY"
-        } >> "$GITHUB_OUTPUT"
+        source "$GITHUB_ACTION_PATH/scripts/resolve-release.sh"
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
     # Cache-first: restore the immutable artifact before any download. A hit skips the
@@ -195,14 +110,10 @@ runs:
       if: inputs.cache != 'true' || steps.cache-restore.outputs.cache-hit != 'true'
       env:
         ARCHIVE: ${{ steps.resolve.outputs.archive }}
-        GITHUB_URL: ${{ steps.resolve.outputs.github-url }}
+        ASSET_API_URL: ${{ steps.resolve.outputs.asset-api-url }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
       run: |
-        set -euo pipefail
-        echo "Downloading $ARCHIVE from $GITHUB_URL"
-        if ! curl -fL --retry 5 --connect-timeout 30 --max-time 600 --no-progress-meter -o "$ARCHIVE" "$GITHUB_URL"; then
-          echo "::error::Could not download $ARCHIVE from $GITHUB_URL"
-          exit 1
-        fi
+        source "$GITHUB_ACTION_PATH/scripts/download-asset.sh"
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
     # Verify on every run, including a cache hit, so a corrupt download or a tampered
@@ -211,11 +122,6 @@ runs:
         ARCHIVE: ${{ steps.resolve.outputs.archive }}
         CHECKSUM: ${{ steps.resolve.outputs.checksum }}
       run: |
-        set -euo pipefail
-        if [ -z "$CHECKSUM" ]; then
-          echo "::error::No published checksum for $ARCHIVE; refusing to install unverified"
-          exit 1
-        fi
         if [ "$RUNNER_OS" = "macOS" ]; then
           echo "$CHECKSUM  $ARCHIVE" | shasum --algorithm 256 --check
         else
@@ -233,7 +139,6 @@ runs:
         ARCHIVE: ${{ steps.resolve.outputs.archive }}
         NAME: ${{ inputs.name }}
       run: |
-        set -euo pipefail
         case "$ARCHIVE" in
           *.tar.gz) tar -zxf "$ARCHIVE" ;;
           *.zip) 7z e "$ARCHIVE" -o"$NAME" ;;
@@ -246,7 +151,6 @@ runs:
         NAME: ${{ inputs.name }}
         INSTALL_DIRECTORY: ${{ steps.resolve.outputs.install-directory }}
       run: |
-        set -euo pipefail
         names=()
         while IFS= read -r executable; do
           if [ -w "$INSTALL_DIRECTORY" ]; then
@@ -270,12 +174,11 @@ runs:
         echo "installed ${names[*]} to $INSTALL_DIRECTORY"
       shell: bash
       working-directory: ${{ steps.system.outputs.working-directory }}
-    - if: always()
+    - if: always() && steps.prepare.outcome == 'success'
       env:
         ARCHIVE: ${{ steps.resolve.outputs.archive }}
         NAME: ${{ inputs.name }}
       run: |
-        set -euo pipefail
         rm -rf "$NAME"
         rm -f "$ARCHIVE"
       shell: bash

--- a/scripts/download-asset.sh
+++ b/scripts/download-asset.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURL_BIN="${CURL_BIN:-curl}"
+auth=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+echo "Downloading $ARCHIVE from the GitHub release asset API"
+if ! "$CURL_BIN" --fail --silent --show-error --location --retry 5 \
+  --connect-timeout 30 --max-time 600 \
+  -H "Accept: application/octet-stream" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${auth[@]}" --output "$ARCHIVE" "$ASSET_API_URL"; then
+  echo "::error::Could not download $ARCHIVE from the GitHub release asset API"
+  exit 1
+fi

--- a/scripts/resolve-release.sh
+++ b/scripts/resolve-release.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+error() {
+  echo "::error::$*"
+}
+
+if ! [[ "$NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  error "name must start with an alphanumeric character and contain only letters, numbers, dots, underscores, or hyphens"
+  exit 1
+fi
+if [ -n "$VERSION" ] && ! [[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+  error "version must start with an alphanumeric character and contain only letters, numbers, dots, underscores, plus signs, or hyphens"
+  exit 1
+fi
+if [ -n "$GITHUB_REPO" ] && ! [[ "$GITHUB_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  error "github-repo must be an owner/repo on GitHub.com"
+  exit 1
+fi
+if ! [[ "$PREFIX" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  error "prefix must start with an alphanumeric character and contain only letters, numbers, dots, underscores, or hyphens"
+  exit 1
+fi
+case "$INSTALL_DIRECTORY" in
+  *$'\n'*|*$'\r'*) error "install-directory must not contain newlines"; exit 1 ;;
+esac
+
+if [ "$OS" = "windows" ]; then EXT="zip"; else EXT="tar.gz"; fi
+SUFFIX="${OS}-${ARCH}.${EXT}"
+
+REPO="$GITHUB_REPO"
+if [ -z "$REPO" ] && [ -f "$GITHUB_ACTION_PATH/distributions.json" ]; then
+  REPO="$(jq -r --arg n "$NAME" '.[$n] // empty' "$GITHUB_ACTION_PATH/distributions.json")"
+fi
+if [ -z "$REPO" ]; then
+  error "No GitHub repository for '$NAME'. Set the github-repo input or add a mapping at https://github.com/ipfs/download-ipfs-distribution-action/blob/v2/distributions.json"
+  exit 1
+fi
+
+GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
+CURL_BIN="${CURL_BIN:-curl}"
+API_BODY=""
+API_STATUS=""
+
+api_get() {
+  local endpoint="$1"
+  local response
+  local auth=()
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+  if ! response="$("$CURL_BIN" --silent --show-error --location --retry 5 \
+    --connect-timeout 30 --max-time 120 \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${auth[@]}" --write-out $'\n%{http_code}' "$GITHUB_API_URL/$endpoint")"; then
+    API_STATUS="network"
+    API_BODY=""
+    return 1
+  fi
+  API_STATUS="${response##*$'\n'}"
+  API_BODY="${response%$'\n'*}"
+  [ "$API_STATUS" = "200" ]
+}
+
+select_asset() {
+  local release_json="$1"
+  local wanted_name="$2"
+  printf '%s' "$release_json" | jq -r --arg want "$wanted_name" '
+    .assets[]?
+    | select(.name == $want)
+    | [.url, (.digest // "")]
+    | @tsv' | head -n1
+}
+
+valid_asset_line() {
+  local line="$1"
+  local digest
+  digest="$(printf '%s' "$line" | cut -f2)"
+  [[ "$digest" =~ ^sha256:[0-9A-Fa-f]{64}$ ]]
+}
+
+resolve_pinned() {
+  ARCHIVE="${NAME}_${VERSION}_${SUFFIX}"
+  if ! api_get "repos/$REPO/releases/tags/$VERSION"; then
+    if [ "$API_STATUS" = "404" ]; then
+      error "Release '$VERSION' was not found in '$REPO', or the token cannot read that repository"
+    else
+      error "Could not query release '$VERSION' in '$REPO' from the GitHub API (status: $API_STATUS)"
+    fi
+    exit 1
+  fi
+
+  local line
+  line="$(select_asset "$API_BODY" "$ARCHIVE")"
+  if [ -z "$line" ]; then
+    error "Release '$VERSION' in '$REPO' does not contain '$ARCHIVE'"
+    exit 1
+  fi
+  if ! valid_asset_line "$line"; then
+    error "Release asset '$ARCHIVE' has no published SHA-256 digest"
+    exit 1
+  fi
+  ASSET_API_URL="$(printf '%s' "$line" | cut -f1)"
+  CHECKSUM="$(printf '%s' "$line" | cut -f2)"
+}
+
+resolve_latest() {
+  local latest_reason="the repository has no designated latest release"
+  local latest_tag=""
+  local latest_line=""
+
+  if api_get "repos/$REPO/releases/latest"; then
+    latest_tag="$(printf '%s' "$API_BODY" | jq -r '.tag_name // empty')"
+    if ! [[ "$latest_tag" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+      latest_reason="release tag '$latest_tag' cannot be represented in an asset filename"
+    elif [ "$(printf '%s' "$API_BODY" | jq -r '.draft == false')" = "true" ] && \
+       [ "$(printf '%s' "$API_BODY" | jq -r '.prerelease == false')" = "true" ]; then
+      ARCHIVE="${NAME}_${latest_tag}_${SUFFIX}"
+      latest_line="$(select_asset "$API_BODY" "$ARCHIVE")"
+      if [ -z "$latest_line" ]; then
+        latest_reason="release '$latest_tag' does not contain '$ARCHIVE'"
+      elif ! valid_asset_line "$latest_line"; then
+        latest_reason="release asset '$ARCHIVE' has no published SHA-256 digest"
+      else
+        VERSION="$latest_tag"
+        ASSET_API_URL="$(printf '%s' "$latest_line" | cut -f1)"
+        CHECKSUM="$(printf '%s' "$latest_line" | cut -f2)"
+        return
+      fi
+    else
+      latest_reason="the designated latest release is a draft or prerelease"
+    fi
+  elif [ "$API_STATUS" != "404" ]; then
+    error "Could not query the latest release in '$REPO' from the GitHub API (status: $API_STATUS)"
+    exit 1
+  fi
+
+  echo "::notice::Falling back from the designated latest release because $latest_reason"
+
+  local page=1
+  local count
+  local candidate
+  local candidate_published
+  local best_line=""
+  local best_published=""
+  while :; do
+    if ! api_get "repos/$REPO/releases?per_page=100&page=$page"; then
+      if [ "$API_STATUS" = "404" ]; then
+        error "Repository '$REPO' was not found, or the token cannot read it"
+      else
+        error "Could not list releases in '$REPO' from the GitHub API (status: $API_STATUS)"
+      fi
+      exit 1
+    fi
+    count="$(printf '%s' "$API_BODY" | jq 'length')"
+    candidate="$(printf '%s' "$API_BODY" | jq -r --arg name "$NAME" --arg suffix "$SUFFIX" '
+      [ .[]
+        | select(.draft == false and .prerelease == false)
+        | select(.tag_name | test("^[A-Za-z0-9][A-Za-z0-9._+-]*$"))
+        | . as $release
+        | ($name + "_" + $release.tag_name + "_" + $suffix) as $want
+        | $release.assets[]?
+        | select(.name == $want and ((.digest // "") | test("^sha256:[0-9A-Fa-f]{64}$")))
+        | [$release.published_at, $release.tag_name, .url, .digest]
+      ]
+      | (max_by(.[0]) // empty)
+      | @tsv')"
+    if [ -n "$candidate" ]; then
+      candidate_published="$(printf '%s' "$candidate" | cut -f1)"
+      if [ -z "$best_line" ] || [[ "$candidate_published" > "$best_published" ]]; then
+        best_line="$candidate"
+        best_published="$candidate_published"
+      fi
+    fi
+    [ "$count" -lt 100 ] && break
+    page=$((page + 1))
+  done
+
+  if [ -z "$best_line" ]; then
+    error "No stable, non-draft release of '$REPO' contains a verifiable '${NAME}_<version>_${SUFFIX}' asset"
+    exit 1
+  fi
+  VERSION="$(printf '%s' "$best_line" | cut -f2)"
+  ASSET_API_URL="$(printf '%s' "$best_line" | cut -f3)"
+  CHECKSUM="$(printf '%s' "$best_line" | cut -f4)"
+  ARCHIVE="${NAME}_${VERSION}_${SUFFIX}"
+}
+
+if [ -n "$VERSION" ]; then
+  resolve_pinned
+else
+  resolve_latest
+fi
+
+CHECKSUM="${CHECKSUM#sha256:}"
+CHECKSUM="$(printf '%s' "$CHECKSUM" | tr '[:upper:]' '[:lower:]')"
+if [ -z "$INSTALL_DIRECTORY" ]; then
+  if [ "$OS" = "windows" ]; then
+    INSTALL_DIRECTORY="/usr/bin"
+  else
+    INSTALL_DIRECTORY="/usr/local/bin"
+  fi
+fi
+
+CACHE_KEY="${PREFIX}-${REPO}-${NAME}-${VERSION}-${OS}-${ARCH}-${CHECKSUM}"
+if [ "${#CACHE_KEY}" -gt 512 ]; then
+  error "The generated cache key is longer than GitHub Actions' 512-character limit; use a shorter prefix"
+  exit 1
+fi
+
+echo "repo=$REPO"
+echo "version=$VERSION"
+echo "archive=$ARCHIVE"
+echo "checksum=sha256:$CHECKSUM"
+echo "cache-key=$CACHE_KEY"
+echo "install-directory=$INSTALL_DIRECTORY"
+
+{
+  echo "archive=$ARCHIVE"
+  echo "asset-api-url=$ASSET_API_URL"
+  echo "checksum=$CHECKSUM"
+  echo "cache-key=$CACHE_KEY"
+  echo "install-directory=$INSTALL_DIRECTORY"
+} >> "$GITHUB_OUTPUT"

--- a/tests/fake-curl.sh
+++ b/tests/fake-curl.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+url=""
+previous=""
+for argument in "$@"; do
+  if [[ "$argument" == http://* || "$argument" == https://* ]]; then
+    url="$argument"
+  fi
+  if [ "$previous" = "Authorization: Bearer fixture-token" ] && [ -n "${AUTH_LOG:-}" ]; then
+    printf 'authorization-present\n' >> "$AUTH_LOG"
+  fi
+  previous="$argument"
+done
+if [ -n "${CALL_LOG:-}" ]; then
+  printf '%s\n' "$url" >> "$CALL_LOG"
+fi
+
+if [ "${FIXTURE_SCENARIO:-}" = "api-error" ]; then
+  printf '\n401'
+  exit 0
+fi
+
+case "$url" in
+  */releases/latest)
+    if [ "${FIXTURE_SCENARIO:-}" = "latest-fallback" ] || [ "${FIXTURE_SCENARIO:-}" = "pagination" ]; then
+      fixture="latest-faulty.json"
+    else
+      fixture="latest-usable.json"
+    fi
+    ;;
+  *'/releases?per_page=100&page=1')
+    if [ "${FIXTURE_SCENARIO:-}" = "pagination" ]; then
+      jq -nc '[range(0; 100) | {tag_name: ("draft-" + tostring), draft: true, prerelease: false, published_at: "2026-07-18T00:00:00Z", assets: []}]'
+      printf '\n200'
+      exit 0
+    fi
+    fixture="releases.json"
+    ;;
+  *'/releases?per_page=100&page=2') fixture="releases.json" ;;
+  */releases/tags/v1.2.3) fixture="latest-usable.json" ;;
+  */releases/tags/v1.2.2) fixture="pinned-missing-digest.json" ;;
+  */releases/tags/v1.2.4) fixture="pinned-missing-asset.json" ;;
+  *) printf '\n404'; exit 0 ;;
+esac
+
+cat "$FIXTURE_ROOT/$fixture"
+printf '\n200'

--- a/tests/fixtures/latest-faulty.json
+++ b/tests/fixtures/latest-faulty.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v2.0.0",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-07-18T12:00:00Z",
+  "assets": []
+}

--- a/tests/fixtures/latest-usable.json
+++ b/tests/fixtures/latest-usable.json
@@ -1,0 +1,13 @@
+{
+  "tag_name": "v1.2.3",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-07-17T12:00:00Z",
+  "assets": [
+    {
+      "name": "kubo_v1.2.3_linux-amd64.tar.gz",
+      "url": "https://api.github.com/repos/example/private-releases/releases/assets/123",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/tests/fixtures/pinned-missing-asset.json
+++ b/tests/fixtures/pinned-missing-asset.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v1.2.4",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-07-18T12:00:00Z",
+  "assets": []
+}

--- a/tests/fixtures/pinned-missing-digest.json
+++ b/tests/fixtures/pinned-missing-digest.json
@@ -1,0 +1,13 @@
+{
+  "tag_name": "v1.2.2",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2025-01-01T12:00:00Z",
+  "assets": [
+    {
+      "name": "kubo_v1.2.2_linux-amd64.tar.gz",
+      "url": "https://api.github.com/repos/example/private-releases/releases/assets/122",
+      "digest": null
+    }
+  ]
+}

--- a/tests/fixtures/releases.json
+++ b/tests/fixtures/releases.json
@@ -1,0 +1,41 @@
+[
+  {
+    "tag_name": "v1.2.3",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-07-17T12:00:00Z",
+    "assets": [
+      {
+        "name": "kubo_v1.2.3_linux-amd64.tar.gz",
+        "url": "https://api.github.com/repos/example/private-releases/releases/assets/123",
+        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  {
+    "tag_name": "v3.0.0-rc1",
+    "draft": false,
+    "prerelease": true,
+    "published_at": "2026-07-18T13:00:00Z",
+    "assets": [
+      {
+        "name": "kubo_v3.0.0-rc1_linux-amd64.tar.gz",
+        "url": "https://api.github.com/repos/example/private-releases/releases/assets/300",
+        "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ]
+  },
+  {
+    "tag_name": "v1.2.2",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2025-01-01T12:00:00Z",
+    "assets": [
+      {
+        "name": "kubo_v1.2.2_linux-amd64.tar.gz",
+        "url": "https://api.github.com/repos/example/private-releases/releases/assets/122",
+        "digest": null
+      }
+    ]
+  }
+]

--- a/tests/redirect-server.py
+++ b/tests/redirect-server.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+log_path, port_path = sys.argv[1:3]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        with open(log_path, "a", encoding="utf-8") as log:
+            log.write(json.dumps({"path": self.path, "authorization": self.headers.get("Authorization")}) + "\n")
+        if self.path == "/asset":
+            self.send_response(302)
+            self.send_header("Location", f"http://localhost:{self.server.server_port}/cdn")
+            self.end_headers()
+            return
+        if self.path == "/cdn":
+            body = b"fixture archive"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        return
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_path, "w", encoding="utf-8") as port_file:
+    port_file.write(str(server.server_port))
+server.serve_forever()

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+run_resolver() {
+  local scenario="$1"
+  local version="$2"
+  local name="${3:-kubo}"
+  : > "$TMP/output"
+  AUTH_LOG="$TMP/auth" \
+  CALL_LOG="$TMP/calls" \
+  FIXTURE_ROOT="$ROOT/tests/fixtures" \
+  FIXTURE_SCENARIO="$scenario" \
+  CURL_BIN="$ROOT/tests/fake-curl.sh" \
+  GITHUB_OUTPUT="$TMP/output" \
+  GITHUB_ACTION_PATH="$ROOT" \
+  GITHUB_API_URL="https://api.github.test" \
+  GITHUB_TOKEN="fixture-token" \
+  NAME="$name" VERSION="$version" GITHUB_REPO="example/private-releases" \
+  INSTALL_DIRECTORY="" OS="linux" ARCH="amd64" PREFIX="fixture" \
+  bash -e -o pipefail "$ROOT/scripts/resolve-release.sh"
+}
+
+run_resolver latest-fallback ""
+grep -q '^archive=kubo_v1.2.3_linux-amd64.tar.gz$' "$TMP/output"
+grep -q '^asset-api-url=https://api.github.com/repos/example/private-releases/releases/assets/123$' "$TMP/output"
+grep -q '^cache-key=fixture-example/private-releases-kubo-v1.2.3-linux-amd64-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$' "$TMP/output"
+grep -q '^authorization-present$' "$TMP/auth"
+
+run_resolver latest ""
+grep -q '^archive=kubo_v1.2.3_linux-amd64.tar.gz$' "$TMP/output"
+
+run_resolver pagination ""
+grep -q '/releases?per_page=100&page=2$' "$TMP/calls"
+
+run_resolver pinned v1.2.3
+grep -q '^archive=kubo_v1.2.3_linux-amd64.tar.gz$' "$TMP/output"
+
+if run_resolver pinned v1.2.2 > "$TMP/missing-digest.log" 2>&1; then
+  echo "expected a missing digest to fail" >&2
+  exit 1
+fi
+grep -q 'has no published SHA-256 digest' "$TMP/missing-digest.log"
+
+if run_resolver pinned v1.2.4 > "$TMP/missing-asset.log" 2>&1; then
+  echo "expected a missing asset to fail" >&2
+  exit 1
+fi
+grep -q 'does not contain' "$TMP/missing-asset.log"
+
+if run_resolver api-error v1.2.3 > "$TMP/api-error.log" 2>&1; then
+  echo "expected an API error to fail closed" >&2
+  exit 1
+fi
+grep -q 'status: 401' "$TMP/api-error.log"
+
+if run_resolver pinned v1.2.3 '../unsafe' > "$TMP/invalid-name.log" 2>&1; then
+  echo "expected an unsafe name to fail" >&2
+  exit 1
+fi
+grep -q 'name must start with an alphanumeric' "$TMP/invalid-name.log"
+
+python3 "$ROOT/tests/redirect-server.py" "$TMP/redirect.log" "$TMP/port" &
+server_pid=$!
+for _ in $(seq 1 50); do
+  [ -s "$TMP/port" ] && break
+  sleep 0.1
+done
+port="$(cat "$TMP/port")"
+(
+  cd "$TMP"
+  ARCHIVE="downloaded-asset" \
+  ASSET_API_URL="http://127.0.0.1:$port/asset" \
+  GITHUB_TOKEN="private-token" \
+  bash -e -o pipefail "$ROOT/scripts/download-asset.sh"
+)
+wait "$server_pid"
+grep -q 'fixture archive' "$TMP/downloaded-asset"
+jq -e 'select(.path == "/asset" and .authorization == "Bearer private-token")' "$TMP/redirect.log" >/dev/null
+jq -e 'select(.path == "/cdn" and .authorization == null)' "$TMP/redirect.log" >/dev/null
+
+echo "script tests passed"


### PR DESCRIPTION
> [!NOTE]
> @galargh, would appreciate your review when you get a chance, no rush. It is a breaking change, so I would suggest cutting it as `@v2`.

## Problem

Every download goes through `dist.ipfs.tech`, a brittle single point of failure: it is four cluster nodes behind a load balancer, so if the one your LB pinned you to is down, your download fails while the others stay up. That recently broke kubo installs in the wild (ipfs/ipfs-desktop#3031: "kubo binary not found", because `ipfs/npm-kubo` could not fetch the binary). Its future is uncertain too: it is slated for shutdown.

## Fix

Fetch release artifacts from each project's GitHub releases instead.

- `distributions.json` maps each name to a GitHub `owner/repo`; the `github-repo` input overrides it for a fork or mirror.
- Implicit `latest` resolves the highest-version release that ships the asset; a pinned version uses a deterministic asset URL.
- Cache-first: an immutable archive is restored before any download and re-verified every run, so a tampered cache entry fails.
- Verification is mandatory against the release API's `sha256` digest; a missing or mismatched checksum fails the action.

Downloads now come from GitHub's CDN, and each project owns its binaries (cluster: ipfs-cluster/ipfs-cluster#2324; kubo already ships them, and we don't care about any legacy packages other than kubo and cluster anyway).

Still, this is breaking, hence the `@v2` suggestion.
